### PR TITLE
Add supporting interfaces for the bigquery collector package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+
+go:
+- '1.8'
+
+# Unconditionally place the repo at GOPATH/src/${go_import_path} to support
+# forks.
+go_import_path: github.com/m-lab/prometheus-bigquery-exporter
+
+
+before_install:
+- go get github.com/mattn/goveralls
+- go get github.com/wadey/gocovmerge
+
+script:
+# Run query "unit tests".
+- go test -v -covermode=count -coverprofile=bq.cov github.com/m-lab/prometheus-bigquery-exporter/bq
+
+# Coveralls
+- $HOME/gopath/bin/gocovmerge bq.cov > merge.cov
+- $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -1,2 +1,77 @@
 # prometheus-bigquery-exporter
-An exporter for converting BigQuery results into Prometheus metrics
+An exporter for converting BigQuery results into Prometheus metrics.
+
+# Limitations
+
+## No historical values
+
+Prometheus collects the *current* status of a system as reported by an exporter.
+Prometheus then associates the values collected with a timestamp of the time of
+collection.
+
+*NOTE:* there is no way to associate historical values with timestamps in the
+the past!
+
+So, the results of queries run by prometheus-bigquery-exporter should represent
+a meaningful value at a fixed point in time, e.g. total number of tests in a 5
+minute window 1 hour ago.
+
+# Query format
+
+The prometheus-bigquery-exporter accepts arbitrary BQ queries. However, the
+query results must be structured in a predictable way for the exporter to
+successfully interpret and convert it into prometheus metrics.
+
+Required columns:
+
+ * `value` -- every query result must have a "value". If there is more than one
+   row, then the query must also define labels to distinguish each value.
+
+   Values should be integers or floats.
+
+Optional columns:
+
+ * `label_*` -- to add metric labels define result columns that use names
+   starting with the prefix `label_`, e.g. `label_machine` will create a label
+   named "machine" with the value taken from the query results for that column.
+
+   Labels should be strings.
+
+There is no limit on the number of labels, but you should respect the prometheus
+best practices by limiting label value cardinality.
+
+## Example query
+
+The following query creates a "machine" label and counts the number of tests
+
+```
+SELECT
+    -- All metric labels should have a column name prefixed with "label_"
+    CONCAT(REPLACE(REGEXP_EXTRACT(task_filename,
+        r'gs://.*-(mlab[1-4]-[a-z]{3}[0-9]+)-ndt.*.tgz'), "-", "."),
+        ".measurement-lab.org") AS label_machine,
+
+    -- All queries must have a single column named "value"
+    count(*) as value
+
+FROM
+    [measurement-lab:public.ndt]
+
+GROUP BY label_machine
+ORDER BY value
+```
+
+Save the sample query to a file named "ndt_test_cound.sql". The metric name is
+derived from the file name. Start the exporter:
+
+```
+    bq_exporter --query counter=ndt_test_count.sql
+```
+
+Visit http://localhost:9393/metrics and you will find metrics like:
+
+```
+    ndt_test_count{machine="mlab1.foo01.measurement-lab.org"} 100
+    ndt_test_count{machine="mlab2.foo01.measurement-lab.org"} 200
+    ...
+```

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ collection.
 the past!
 
 So, the results of queries run by prometheus-bigquery-exporter should represent
-a meaningful value at a fixed point in time, e.g. total number of tests in a 5
-minute window 1 hour ago.
+a meaningful value at a fixed point in time relative to the time the query is
+made, e.g. total number of tests in a 5 minute window 1 hour ago.
 
 # Query format
 
@@ -24,29 +24,31 @@ successfully interpret and convert it into prometheus metrics.
 
 Required columns:
 
- * `value` -- every query result must have a "value". If there is more than one
-   row, then the query must also define labels to distinguish each value.
-
-   Values should be integers or floats.
+ * `value` -- every query result must have a "value". Values should be integers
+   or floats.
 
 Optional columns:
 
- * `label_*` -- to add metric labels define result columns that use names
-   starting with the prefix `label_`, e.g. `label_machine` will create a label
-   named "machine" with the value taken from the query results for that column.
+ * If there is more than one result row, then the query must also define labels
+   to distinguish each value. Every column name that is not "value" will create
+   a label on the resulting metric. For example, results with two columns,
+   "machine" and "value" would create metrics with labels named "machine" and
+   values from the results for that row.
 
    Labels should be strings.
 
-There is no limit on the number of labels, but you should respect the prometheus
-best practices by limiting label value cardinality.
+   There is no limit on the number of labels, but you should respect the
+   prometheus best practices by limiting label value cardinality.
 
 ## Example query
 
 The following query creates a "machine" label and counts the number of tests
 
 ```
+# TODO: replace with query using views.
+# TODO: replace with standard SQL syntax.
 SELECT
-    -- All metric labels should have a column name prefixed with "label_"
+    -- All columns not named "value" are added as metric labels.
     CONCAT(REPLACE(REGEXP_EXTRACT(task_filename,
         r'gs://.*-(mlab[1-4]-[a-z]{3}[0-9]+)-ndt.*.tgz'), "-", "."),
         ".measurement-lab.org") AS label_machine,

--- a/bq/query_runner.go
+++ b/bq/query_runner.go
@@ -43,7 +43,7 @@ func (qr *queryRunnerImpl) Query(query string) ([]Metric, error) {
 
 	q := qr.client.Query(query)
 
-	// TODO: check query string for SQL type.
+	// TODO: only use Standard SQL.
 	q.QueryConfig.UseLegacySQL = true
 
 	// TODO: add context timeout.

--- a/bq/query_runner.go
+++ b/bq/query_runner.go
@@ -1,0 +1,117 @@
+// query_runner defines the QueryRunner interface for running bigquery queries
+// and converting the results into a set of key/value labels and a single
+// float64 value suitable for converting into a prometheus.Metric.
+package bq
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+
+	"cloud.google.com/go/bigquery"
+	"google.golang.org/api/iterator"
+)
+
+type QueryRunner interface {
+	Query(q string) ([]Metric, error)
+}
+
+type queryRunnerImpl struct {
+	client *bigquery.Client
+}
+
+// metric holds raw data from query results needed to create a prometheus.Metric.
+type Metric struct {
+	labels []string
+	values []string
+	value  float64
+}
+
+// NewQueryRunner creates a new query runner instance.
+func NewQueryRunner(client *bigquery.Client) QueryRunner {
+	return &queryRunnerImpl{client}
+}
+
+// Query executes the given query
+func (qr *queryRunnerImpl) Query(query string) ([]Metric, error) {
+	metrics := []Metric{}
+
+	q := qr.client.Query(query)
+
+	// TODO: check query string for SQL type.
+	q.QueryConfig.UseStandardSQL = false
+
+	// TODO: add context timeout.
+	it, err := q.Read(context.Background())
+	if err != nil {
+		log.Print(err)
+		return nil, err
+	}
+
+	for {
+		var row map[string]bigquery.Value
+		err := it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Printf("%#v %d", err, len(metrics))
+			return nil, err
+		}
+		metrics = append(metrics, rowToMetric(row))
+	}
+	return metrics, nil
+}
+
+// valToFloat extracts a float from the bigquery.Value irrespective of the
+// underlying type. If the type is not int64, float64, then valToFloat returns
+// zero.
+func valToFloat(v bigquery.Value) float64 {
+	switch v.(type) {
+	case int64:
+		return (float64)(v.(int64))
+	case float64:
+		return v.(float64)
+	default:
+		return 0
+	}
+}
+
+// valToString coerces the bigquery.Value into a string. If the underlying type
+// is not a string, we treat it like an int64 or float64. If the underlying is
+// none of these types, valToString returns "0".
+func valToString(v bigquery.Value) string {
+	var s string
+	switch v.(type) {
+	case string:
+		s = v.(string)
+	default:
+		// This should not happen too often, but if it does, hardcode 2 decimal
+		// points to try to protect label value cardinailty.
+		s = fmt.Sprintf("%.2f", valToFloat(v))
+	}
+	return s
+}
+
+// rowToMetric converts a bigquery result row to a bq.Metric
+func rowToMetric(row map[string]bigquery.Value) Metric {
+	m := Metric{}
+	// Since `range` does not guarantee map key order, we must extract, sort
+	// and then extract values.
+	for k, v := range row {
+		if strings.HasPrefix(k, "label_") {
+			m.labels = append(m.labels, strings.TrimPrefix(k, "label_"))
+		} else if k == "value" {
+			m.value = valToFloat(v)
+		}
+	}
+	sort.Strings(m.labels)
+
+	for i := range m.labels {
+		key := fmt.Sprintf("label_%s", m.labels[i])
+		m.values = append(m.values, valToString(row[key]))
+	}
+	return m
+}

--- a/bq/query_runner_test.go
+++ b/bq/query_runner_test.go
@@ -1,0 +1,59 @@
+package bq
+
+import (
+	"reflect"
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+)
+
+func TestRowToMetric(t *testing.T) {
+	tests := []struct {
+		name   string
+		row    map[string]bigquery.Value
+		metric Metric
+	}{
+		{
+			name: "Extract labels",
+			row: map[string]bigquery.Value{
+				"label_machine": "mlab1.foo01.measurement-lab.org",
+				"value":         1.0,
+			},
+			metric: Metric{
+				labels: []string{"machine"},
+				values: []string{"mlab1.foo01.measurement-lab.org"},
+				value:  1.0,
+			},
+		},
+		{
+			name: "No labels",
+			row: map[string]bigquery.Value{
+				"value": 1.1,
+			},
+			metric: Metric{
+				labels: nil,
+				values: nil,
+				value:  1.1,
+			},
+		},
+		{
+			name: "Bad label values are converted to strings",
+			row: map[string]bigquery.Value{
+				"label_name": 3.0, // should be a string.
+				"value":      2.1,
+			},
+			metric: Metric{
+				labels: []string{"name"},
+				values: []string{"3.00"}, // converted to a string.
+				value:  2.1,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		m := rowToMetric(test.row)
+		if !reflect.DeepEqual(m, test.metric) {
+			t.Error("Failed to convert row to metric. want %#v; got %#v", test.metric, m)
+		}
+	}
+}

--- a/bq/query_runner_test.go
+++ b/bq/query_runner_test.go
@@ -55,7 +55,7 @@ func TestRowToMetric(t *testing.T) {
 			},
 			metric: Metric{
 				labels: []string{"name"},
-				values: []string{"3.00"}, // converted to a string.
+				values: []string{"invalid string"}, // converted to a string.
 				value:  2.1,
 			},
 		},

--- a/bq/query_runner_test.go
+++ b/bq/query_runner_test.go
@@ -16,8 +16,8 @@ func TestRowToMetric(t *testing.T) {
 		{
 			name: "Extract labels",
 			row: map[string]bigquery.Value{
-				"label_machine": "mlab1.foo01.measurement-lab.org",
-				"value":         1.0,
+				"machine": "mlab1.foo01.measurement-lab.org",
+				"value":   1.0,
 			},
 			metric: Metric{
 				labels: []string{"machine"},
@@ -50,8 +50,8 @@ func TestRowToMetric(t *testing.T) {
 		{
 			name: "Bad label values are converted to strings",
 			row: map[string]bigquery.Value{
-				"label_name": 3.0, // should be a string.
-				"value":      2.1,
+				"name":  3.0, // should be a string.
+				"value": 2.1,
 			},
 			metric: Metric{
 				labels: []string{"name"},

--- a/bq/query_runner_test.go
+++ b/bq/query_runner_test.go
@@ -37,6 +37,17 @@ func TestRowToMetric(t *testing.T) {
 			},
 		},
 		{
+			name: "Integer value",
+			row: map[string]bigquery.Value{
+				"value": int64(10),
+			},
+			metric: Metric{
+				labels: nil,
+				values: nil,
+				value:  10,
+			},
+		},
+		{
 			name: "Bad label values are converted to strings",
 			row: map[string]bigquery.Value{
 				"label_name": 3.0, // should be a string.


### PR DESCRIPTION
This change adds a support package for the bigquery prometheus Collector interface. This change only includes the definition of the QueryRunner interface and supporting functions.

This change also adds documentation to the README to outline usage of the exporter. And, this change adds basic .travis.yml configuration with Go coverage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-bigquery-exporter/1)
<!-- Reviewable:end -->
