### PR TITLE
Add bigquery_exporter command

### DIFF
--- a/cmd/bigquery_exporter/main.go
+++ b/cmd/bigquery_exporter/main.go
@@ -1,4 +1,8 @@
-// bigquery_exporter
+// bigquery_exporter runs structured bigquery SQL and converts the results into
+// prometheus metrics. bigquery_exporter can process multiple queries.
+// Because BigQuery queries can have long run times and high cost, Query results
+// are cached and updated every refresh interval, not on every scrape of
+// prometheus metrics.
 package main
 
 import (
@@ -41,21 +45,6 @@ func init() {
 func sleepUntilNext(d time.Duration) {
 	next := time.Now().Truncate(d).Add(d)
 	time.Sleep(time.Until(next))
-}
-
-type sleepDelay struct {
-	dur time.Duration
-}
-
-// d := sleepDelay{*refresh}
-// time.Sleep(d.Next(time.Now()))
-// sleepUntilNext(*refresh)
-func (d *delay) Next(t time.Time) time.Duration {
-	return time.Until(t.Truncate(d.dur).Add(d.dur))
-}
-
-func untilNext(d time.Duration) time.Duration {
-	return time.Until(time.Now().Truncate(d).Add(d))
 }
 
 // fileToMetric extracts the base file name to use as a prometheus metric name.

--- a/cmd/bigquery_exporter/main.go
+++ b/cmd/bigquery_exporter/main.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/m-lab/prometheus-bigquery-exporter/bq"
+
+	flag "github.com/spf13/pflag"
+
+	"cloud.google.com/go/bigquery"
+	"golang.org/x/net/context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	valueTypes   = []string{}
+	querySources = []string{}
+	project      = flag.String("project", "", "GCP project name.")
+	refresh      = flag.Duration("refresh", 5*time.Minute, "Number of seconds between refreshing.")
+)
+
+func init() {
+	flag.StringArrayVar(&valueTypes, "type", nil, "Name of the prometheus value type, e.g. 'counter' or 'gauge'.")
+	flag.StringArrayVar(&querySources, "query", nil, "Name of file with query string.")
+
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
+// sleepUntilNext finds the nearest future time that is a multiple of the given
+// duration and sleeps until that time.
+func sleepUntilNext(d time.Duration) {
+	next := time.Now().Truncate(d).Add(d)
+	time.Sleep(time.Until(next))
+}
+
+// fileToMetric extracts the base file name to use as a prometheus metric name.
+func fileToMetric(filename string) string {
+	fname := filepath.Base(filename)
+	return strings.TrimSuffix(fname, filepath.Ext(fname))
+}
+
+// registerCollector
+func createCollector(typeName, filename string, refresh time.Duration) (*bq.Collector, error) {
+	queryBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	client, err := bigquery.NewClient(ctx, *project)
+	if err != nil {
+		return nil, err
+	}
+
+	var v prometheus.ValueType
+	if typeName == "counter" {
+		v = prometheus.CounterValue
+	} else if typeName == "gauge" {
+		v = prometheus.GaugeValue
+	} else {
+		v = prometheus.UntypedValue
+	}
+
+	query := string(queryBytes)
+	query = strings.Replace(query, "UNIX_START_TIME", fmt.Sprintf("%d", time.Now().UTC().Unix()), -1)
+	query = strings.Replace(query, "REFRESH_RATE_SEC", fmt.Sprintf("%d", int(refresh.Seconds())), -1)
+
+	c := bq.NewCollector(bq.NewQueryRunner(client), v, fileToMetric(filename), string(query))
+
+	return c, nil
+}
+
+func updatePeriodically(collectors, unregistered []*bq.Collector, refresh time.Duration) {
+	var registered = []*bq.Collector{}
+
+	if len(unregistered) > 0 {
+	}
+	tryRegister(unregistered)
+		err := prometheus.Register(c)
+
+	for sleepUntilNext(refresh); ; sleepUntilNext(refresh) {
+		log.Printf("Starting a new round at: %s", time.Now())
+		for i := range collectors {
+			log.Printf("Running query for %s", collectors[i])
+			collectors[i].Update()
+			log.Printf("Done")
+		}
+	}
+}
+
+func tryRegister(unregistered []*bq.Collector) error {
+		// Attempt to register collector. If it fails, retry later.
+	}
+}
+
+func main() {
+	flag.Parse()
+	var unregistered = []*bq.Collector{}
+
+	if len(querySources) != len(valueTypes) {
+		log.Fatal("You must provide a --type flag for every --query source.")
+	}
+
+	for i := range querySources {
+		c, err := createCollector(valueTypes[i], querySources[i], *refresh)
+		if err != nil {
+			log.Printf("Failed to create collector %s: %s", querySources[i], err)
+			continue
+		}
+		unregistered = append(unregistered, c)
+	}
+
+	go updatePeriodically(unregistered, *refresh)
+
+	http.Handle("/metrics", promhttp.Handler())
+	log.Fatal(http.ListenAndServe(":9393", nil))
+}

--- a/cmd/bigquery_exporter/main.go
+++ b/cmd/bigquery_exporter/main.go
@@ -43,6 +43,21 @@ func sleepUntilNext(d time.Duration) {
 	time.Sleep(time.Until(next))
 }
 
+type sleepDelay struct {
+	dur time.Duration
+}
+
+// d := sleepDelay{*refresh}
+// time.Sleep(d.Next(time.Now()))
+// sleepUntilNext(*refresh)
+func (d *delay) Next(t time.Time) time.Duration {
+	return time.Until(t.Truncate(d.dur).Add(d.dur))
+}
+
+func untilNext(d time.Duration) time.Duration {
+	return time.Until(time.Now().Truncate(d).Add(d))
+}
+
 // fileToMetric extracts the base file name to use as a prometheus metric name.
 func fileToMetric(filename string) string {
 	fname := filepath.Base(filename)
@@ -92,7 +107,6 @@ func updatePeriodically(unregistered chan *bq.Collector, refresh time.Duration) 
 	if len(unregistered) > 0 {
 		collectors = append(collectors, tryRegister(unregistered)...)
 	}
-
 	for sleepUntilNext(refresh); ; sleepUntilNext(refresh) {
 		log.Printf("Starting a new round at: %s", time.Now())
 		for i := range collectors {

--- a/cmd/bigquery_exporter/main.go
+++ b/cmd/bigquery_exporter/main.go
@@ -1,3 +1,4 @@
+// bigquery_exporter
 package main
 
 import (
@@ -82,7 +83,8 @@ func createCollector(filename, typeName string, vars map[string]string) (*bq.Col
 	return c, nil
 }
 
-// updatePeriodically
+// updatePeriodically runs in an infinite loop, an updates registered
+// collectors every refresh period.
 func updatePeriodically(unregistered chan *bq.Collector, refresh time.Duration) {
 	var collectors = []*bq.Collector{}
 
@@ -104,7 +106,9 @@ func updatePeriodically(unregistered chan *bq.Collector, refresh time.Duration) 
 	}
 }
 
-// tryRegister
+// tryRegister attempts to prometheus.Register every bq.Collectors queued in
+// unregistered. Any collectors that fail are placed back on the channel. All
+// successfully registered collectors are returned.
 func tryRegister(unregistered chan *bq.Collector) []*bq.Collector {
 	var registered = []*bq.Collector{}
 	count := len(unregistered)


### PR DESCRIPTION
This change adds the implementation of the `bigquery_exporter` command.

The `bigquery_exporter` accepts SQL files via `--query` flag that can be specified multiple times.

Queries are refreshed every "--refresh" interval.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-bigquery-exporter/3)
<!-- Reviewable:end -->
