### PR TITLE
Add minimal Dockerfile for bigquery_exporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.8
+COPY . /go/src/github.com/m-lab/prometheus-bigquery-exporter
+RUN go get -v github.com/m-lab/prometheus-bigquery-exporter/cmd/bigquery_exporter
+ENTRYPOINT ["/go/bin/bigquery_exporter"]


### PR DESCRIPTION
This change adds a Dockerfile for the `bigquery_exporter`. This should be built on tags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-bigquery-exporter/4)
<!-- Reviewable:end -->
