### PR TITLE
Use StandardSQL by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 
 script:
 # Run query "unit tests".
-- go test -v -covermode=count -coverprofile=bq.cov github.com/m-lab/prometheus-bigquery-exporter/bq
+- go test -v -short -covermode=count -coverprofile=bq.cov github.com/m-lab/prometheus-bigquery-exporter/bq
 
 # Coveralls
 - $HOME/gopath/bin/gocovmerge bq.cov > merge.cov

--- a/bq/live_test.go
+++ b/bq/live_test.go
@@ -1,0 +1,67 @@
+package bq_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/prometheus-bigquery-exporter/bq"
+)
+
+// TestLiveQuery uses a real BigQuery client to connect and run actual queries.
+// Requires auth credentials.
+// Note: disable this test in travis by specifying "go test -short [...]"
+func TestLiveQuery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping live query tests.")
+	}
+	ctx := context.Background()
+	client, err := bigquery.NewClient(ctx, "mlab-sandbox")
+	if err != nil {
+		t.Fatal(err)
+	}
+	qr := bq.NewQueryRunner(client)
+	tests := []struct {
+		name    string
+		query   string
+		metrics []bq.Metric
+	}{
+		{
+			name:  "Single value",
+			query: "SELECT 1 as value",
+			metrics: []bq.Metric{
+				bq.NewMetric(nil, nil, 1.0),
+			},
+		},
+		{
+			name:  "Single value with label",
+			query: "SELECT 'foo' as key, 2 as value",
+			metrics: []bq.Metric{
+				bq.NewMetric([]string{"key"}, []string{"foo"}, 2.0),
+			},
+		},
+		{
+			name: "Multiple values with labels",
+			query: `#standardSQL
+			        SELECT key, value
+					FROM (SELECT "foo" AS key, 1 AS value UNION ALL
+					      SELECT "bar" AS key, 2 AS value);`,
+			metrics: []bq.Metric{
+				bq.NewMetric([]string{"key"}, []string{"foo"}, 1.0),
+				bq.NewMetric([]string{"key"}, []string{"bar"}, 2.0),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Logf("Live query test: %s", test.name)
+		metrics, err := qr.Query(test.query)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(metrics, test.metrics) {
+			t.Errorf("Metrics do not match:\nwant %#v;\n got %#v", test.metrics, metrics)
+		}
+	}
+
+}

--- a/bq/query_runner.go
+++ b/bq/query_runner.go
@@ -25,6 +25,11 @@ type Metric struct {
 	value  float64
 }
 
+// NewMetric creates a Metric with given values.
+func NewMetric(labels []string, values []string, value float64) Metric {
+	return Metric{labels, values, value}
+}
+
 // queryRunnerImpl is a concerete implementation of QueryRunner for BigQuery.
 type queryRunnerImpl struct {
 	client *bigquery.Client
@@ -35,17 +40,13 @@ func NewQueryRunner(client *bigquery.Client) QueryRunner {
 	return &queryRunnerImpl{client}
 }
 
-// Query executes the given query. Currently only Legacy SQL is supported. The
-// query must define a column named "value" for the value, and may define label
-// columns that use the prefix "label_".
+// Query executes the given query. Query only supports standard SQL. The
+// query must define a column named "value" for the value, and may define
+// additional columns, all of which are used as metric labels.
 func (qr *queryRunnerImpl) Query(query string) ([]Metric, error) {
 	metrics := []Metric{}
 
 	q := qr.client.Query(query)
-
-	// TODO: only use Standard SQL.
-	q.QueryConfig.UseLegacySQL = true
-
 	// TODO: add context timeout.
 	it, err := q.Read(context.Background())
 	if err != nil {


### PR DESCRIPTION
This change disables support for Legacy SQL in the bigquery exporter.

As well, this change adds a live bigquery test of the queryRunner.Query function. To disable this during travis builds, we use the go test `-short` flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-bigquery-exporter/5)
<!-- Reviewable:end -->
