### PR TITLE
Support exporting multiple values per query

### DIFF
--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,0 +1,7 @@
+FROM google/cloud-sdk
+RUN curl -O  https://storage.googleapis.com/golang/go1.8.5.linux-amd64.tar.gz
+RUN tar -C /usr/local -xf /go1.8.5.linux-amd64.tar.gz
+RUN rm -f /go1.8.5.linux-amd64.tar.gz
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin
+ENTRYPOINT ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -77,3 +77,43 @@ Visit http://localhost:9393/metrics and you will find metrics like:
     ndt_test_count{machine="mlab2.foo01.measurement-lab.org"} 200
     ...
 ```
+
+
+# Testing
+
+To run the bigquery exporter locally (e.g. with a new query) you can build a
+test environment based on the google/cloud-sdk with a golang tools installed.
+
+Use the following steps:
+
+1. Build the testing docker image.
+
+```
+$ docker build -t bqe.testing -f Dockerfile.testing .
+```
+
+2. Run the testing image, with fowarded ports and shared volume. The
+   `--volumes-from` option is created automatically by the cloud-sdk base image.
+   This volume preserves credentials across runs of the docker image.
+
+```
+$ docker run -p 9050:9050 --rm -ti -v $PWD:/go/src/github.com/m-lab/prometheus-bigquery-exporter --volumes-from gcloud-config bqe.testing
+```
+
+3. Authenticate using your account. Both steps are necessary, the first to run
+   gcloud commands (which uses user credentials), the second to run the bigquery
+   exporter (which uses application default credentials).
+
+```
+# gcloud auth login
+# gcloud auth application-default login
+```
+
+4. Start the bigquery exporter.
+
+```
+go get -v github.com/m-lab/prometheus-bigquery-exporter/cmd/bigquery_exporter
+./go/bin/bigquery_exporter \
+    --project mlab-sandbox \
+    --type gauge --query <path-to-some-query-file>/bq_ndt_metrics.sql
+```

--- a/bq/bq.go
+++ b/bq/bq.go
@@ -8,15 +8,23 @@ import (
 )
 
 type Collector struct {
-	runner     QueryRunner
+	// runner must be a QueryRunner instance for collecting metrics.
+	runner QueryRunner
+	// metricName is the base name for prometheus metrics created for this query.
 	metricName string
-	query      string
+	// query contains the standardSQL query.
+	query string
 
+	// valType defines whether the metric is a Gauge or Counter type.
 	valType prometheus.ValueType
-	descs   map[string]*prometheus.Desc
+	// descs maps metric suffixes to the prometheus description. These descriptions
+	// are generated once and must be stable over time.
+	descs map[string]*prometheus.Desc
 
+	// metrics caches the last set of collected results from a query.
 	metrics []Metric
-	mux     sync.Mutex
+	// mux locks access to types above.
+	mux sync.Mutex
 }
 
 // NewCollector creates a new BigQuery Collector instance.

--- a/bq/bq_test.go
+++ b/bq/bq_test.go
@@ -23,14 +23,14 @@ func (qr *fakeQueryRunner) Query(query string) ([]Metric, error) {
 func TestCollector(t *testing.T) {
 	metrics := []Metric{
 		Metric{
-			labels: []string{"key"},
-			values: []string{"thing"},
-			value:  1.1,
+			labelKeys:   []string{"key"},
+			labelValues: []string{"thing"},
+			values:      map[string]float64{"": 1.1},
 		},
 		Metric{
-			labels: []string{"key"},
-			values: []string{"thing2"},
-			value:  2.1,
+			labelKeys:   []string{"key"},
+			labelValues: []string{"thing2"},
+			values:      map[string]float64{"": 2.1},
 		},
 	}
 	expectedMetrics := []string{

--- a/bq/live_test.go
+++ b/bq/live_test.go
@@ -28,28 +28,39 @@ func TestLiveQuery(t *testing.T) {
 		metrics []bq.Metric
 	}{
 		{
-			name:  "Single value",
+			name:  "Single row, single value",
 			query: "SELECT 1 as value",
 			metrics: []bq.Metric{
-				bq.NewMetric(nil, nil, 1.0),
+				bq.NewMetric(nil, nil, map[string]float64{"": 1.0}),
 			},
 		},
 		{
-			name:  "Single value with label",
+			name:  "Single row, single value with label",
 			query: "SELECT 'foo' as key, 2 as value",
 			metrics: []bq.Metric{
-				bq.NewMetric([]string{"key"}, []string{"foo"}, 2.0),
+				bq.NewMetric([]string{"key"}, []string{"foo"}, map[string]float64{"": 2.0}),
 			},
 		},
 		{
-			name: "Multiple values with labels",
+			name: "Multiple rows, single value with labels",
 			query: `#standardSQL
 			        SELECT key, value
 					FROM (SELECT "foo" AS key, 1 AS value UNION ALL
 					      SELECT "bar" AS key, 2 AS value);`,
 			metrics: []bq.Metric{
-				bq.NewMetric([]string{"key"}, []string{"foo"}, 1.0),
-				bq.NewMetric([]string{"key"}, []string{"bar"}, 2.0),
+				bq.NewMetric([]string{"key"}, []string{"foo"}, map[string]float64{"": 1.0}),
+				bq.NewMetric([]string{"key"}, []string{"bar"}, map[string]float64{"": 2.0}),
+			},
+		},
+		{
+			name: "Multiple rows, multiple values with labels",
+			query: `#standardSQL
+			        SELECT key, value_foo, value_bar
+					FROM (SELECT "foo" AS key, 1 AS value_foo, 3 as value_bar UNION ALL
+					      SELECT "bar" AS key, 2 AS value_foo, 4 as value_bar);`,
+			metrics: []bq.Metric{
+				bq.NewMetric([]string{"key"}, []string{"foo"}, map[string]float64{"_foo": 1.0, "_bar": 3.0}),
+				bq.NewMetric([]string{"key"}, []string{"bar"}, map[string]float64{"_foo": 2.0, "_bar": 4.0}),
 			},
 		},
 	}

--- a/bq/query_runner_test.go
+++ b/bq/query_runner_test.go
@@ -20,9 +20,9 @@ func TestRowToMetric(t *testing.T) {
 				"value":   1.0,
 			},
 			metric: Metric{
-				labels: []string{"machine"},
-				values: []string{"mlab1.foo01.measurement-lab.org"},
-				value:  1.0,
+				labelKeys:   []string{"machine"},
+				labelValues: []string{"mlab1.foo01.measurement-lab.org"},
+				values:      map[string]float64{"": 1.0},
 			},
 		},
 		{
@@ -31,9 +31,9 @@ func TestRowToMetric(t *testing.T) {
 				"value": 1.1,
 			},
 			metric: Metric{
-				labels: nil,
-				values: nil,
-				value:  1.1,
+				labelKeys:   nil,
+				labelValues: nil,
+				values:      map[string]float64{"": 1.1},
 			},
 		},
 		{
@@ -42,9 +42,21 @@ func TestRowToMetric(t *testing.T) {
 				"value": int64(10),
 			},
 			metric: Metric{
-				labels: nil,
-				values: nil,
-				value:  10,
+				labelKeys:   nil,
+				labelValues: nil,
+				values:      map[string]float64{"": 10},
+			},
+		},
+		{
+			name: "Multiple values",
+			row: map[string]bigquery.Value{
+				"value_foo": int64(10),
+				"value_bar": int64(20),
+			},
+			metric: Metric{
+				labelKeys:   nil,
+				labelValues: nil,
+				values:      map[string]float64{"_foo": 10, "_bar": 20},
 			},
 		},
 		{
@@ -54,9 +66,9 @@ func TestRowToMetric(t *testing.T) {
 				"value": 2.1,
 			},
 			metric: Metric{
-				labels: []string{"name"},
-				values: []string{"invalid string"}, // converted to a string.
-				value:  2.1,
+				labelKeys:   []string{"name"},
+				labelValues: []string{"invalid string"}, // converted to a string.
+				values:      map[string]float64{"": 2.1},
 			},
 		},
 	}


### PR DESCRIPTION
This change adds the ability for the bigquery exporter to run queries and interpret results that contain multiple values. Each distinct value is identified by a suffix to columns with the prefix `value`. So, for example, columns named `value_foo` will create metrics name `<metric>_foo <value>`.

This change allows us to consolidate and run more efficient queries for which we want multiple values, such as avg upload, avg download, and avg up/down rtt per machine

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-bigquery-exporter/9)
<!-- Reviewable:end -->
