### PR TITLE
Fix comment for valToString

### DIFF
--- a/bq/query_runner.go
+++ b/bq/query_runner.go
@@ -86,7 +86,7 @@ func valToFloat(v bigquery.Value) float64 {
 
 // valToString coerces the bigquery.Value into a string. If the underlying type
 // is not a string, we treat it like an int64 or float64. If the underlying is
-// none of these types, valToString returns "0".
+// none of these types, valToString returns "invalid string".
 func valToString(v bigquery.Value) string {
 	var s string
 	switch v.(type) {


### PR DESCRIPTION
If a value can't be verified as type String, the function returns a new string "invalid string" instead of "0". Clarifying the comment to match the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-bigquery-exporter/15)
<!-- Reviewable:end -->
