### PR TITLE
Allow time.Time types to be converted to string labels

### DIFF
--- a/bq/query_runner.go
+++ b/bq/query_runner.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"google.golang.org/api/iterator"
@@ -85,13 +86,16 @@ func valToFloat(v bigquery.Value) float64 {
 }
 
 // valToString coerces the bigquery.Value into a string. If the underlying type
-// is not a string, we treat it like an int64 or float64. If the underlying is
-// none of these types, valToString returns "invalid string".
+// is not a string, we check against other special types such as time.Time and
+// try to convert to a string. If the underlying is none of these types, valToString
+// returns "invalid string".
 func valToString(v bigquery.Value) string {
 	var s string
 	switch v.(type) {
 	case string:
 		s = v.(string)
+	case time.Time:
+		s = v.(time.Time).String()
 	default:
 		s = "invalid string"
 	}

--- a/bq/query_runner_test.go
+++ b/bq/query_runner_test.go
@@ -3,6 +3,7 @@ package bq
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 )
@@ -69,6 +70,18 @@ func TestRowToMetric(t *testing.T) {
 				labelKeys:   []string{"name"},
 				labelValues: []string{"invalid string"}, // converted to a string.
 				values:      map[string]float64{"": 2.1},
+			},
+		},
+		{
+			name: "Convert time.Time type into string",
+			row: map[string]bigquery.Value{
+				"timestamp": time.Date(2019, time.September, 26, 0, 0, 0, 0, time.UTC), //
+				"value":     1.0,
+			},
+			metric: Metric{
+				labelKeys:   []string{"timestamp"},
+				labelValues: []string{"2019-09-26 00:00:00 +0000 UTC"}, // converted to a string.
+				values:      map[string]float64{"": 1.0},
 			},
 		},
 	}


### PR DESCRIPTION
Some bigquery tables use timestamps as part of their schema and right now should one try to export the data, the resulting data points in prometheus have "invalid string" instead of string converted versions of the timestamps. This change would allow users to convert timestamps to strings and keep the labels as is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-bigquery-exporter/16)
<!-- Reviewable:end -->
