### PR TITLE
Add internal setup package for managing file loading and registration

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/m-lab/prometheus-bigquery-exporter/sql"
@@ -30,7 +31,7 @@ func (f *File) IsModified() (bool, error) {
 	}
 	curr, err := fs.Stat(f.Name)
 	if err != nil {
-		// TODO: best way to handle this?
+		log.Printf("Failed to stat %q: %v", f.Name, err)
 		return false, err
 	}
 	return curr.ModTime().After(f.stat.ModTime()), nil

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -37,8 +37,8 @@ func (f *File) IsModified() (bool, error) {
 }
 
 // Register the given collector. If a collector was previously registered with
-// this file, then it is unregistered first. If either registration or unregister fails, then the error is returned.
-// NOTE: it is possible
+// this file, then it is unregistered first. If either registration or
+// unregister fails, then the error is returned.
 func (f *File) Register(c *sql.Collector) error {
 	if f.c != nil {
 		ok := prometheus.Unregister(f.c)

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -1,0 +1,68 @@
+package setup
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/m-lab/prometheus-bigquery-exporter/sql"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/afero"
+)
+
+var fs = afero.NewOsFs()
+
+// File represents a query file and related metadata to keep it up to date and
+// registered with the prometheus collector registry.
+type File struct {
+	Name string
+	stat os.FileInfo
+	c    *sql.Collector
+}
+
+// IsModified reports true if the file has been modified since the last call.
+// The first call should almost always return false.
+func (f *File) IsModified() (bool, error) {
+	var err error
+	if f.stat == nil {
+		f.stat, err = fs.Stat(f.Name)
+		// Return true on the first successful Stat(), or the error otherwise.
+		return err == nil, err
+	}
+	curr, err := fs.Stat(f.Name)
+	if err != nil {
+		// TODO: best way to handle this?
+		return false, err
+	}
+	return curr.ModTime().After(f.stat.ModTime()), nil
+}
+
+// Register the given collector. If a collector was previously registered with
+// this file, then it is unregistered first. If either registration or unregister fails, then the error is returned.
+// NOTE: it is possible
+func (f *File) Register(c *sql.Collector) error {
+	if f.c != nil {
+		ok := prometheus.Unregister(f.c)
+		if !ok {
+			// This is a fatal error. If the
+			return fmt.Errorf("Failed to unregister %q", f.Name)
+		}
+		f.c = nil
+	}
+	// Register runs c.Update().
+	err := prometheus.Register(c)
+	if err != nil {
+		// While collector Update could fail transiently, this may be a fatal error.
+		return err
+	}
+	// Save the registered collector.
+	f.c = c
+	return nil
+}
+
+// Update runs the collector query again.
+func (f *File) Update() error {
+	if f.c != nil {
+		return f.c.Update()
+	}
+	return nil
+}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1,0 +1,159 @@
+package setup
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/prometheus-bigquery-exporter/sql"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/afero"
+)
+
+func TestFile_IsModified(t *testing.T) {
+	// Override the package afero.OsFs with a local memory fs with a single file.
+	fs = afero.NewMemMapFs()
+	fs.Create("localfile")
+
+	// Create a fake stat object that's before current time of localfile.
+	fs.Create("fakestat")
+	before := time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
+	fs.Chtimes("fakestat", before, before)
+	s, err := fs.Stat("fakestat")
+	rtx.Must(err, "Failed to stat filesystem")
+
+	tests := []struct {
+		name    string
+		file    *File
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "success-first-run",
+			file: &File{
+				Name: "localfile",
+			},
+			want: true,
+		},
+		{
+			name: "success-second-run",
+			file: &File{
+				Name: "localfile",
+				stat: s,
+			},
+			want: true,
+		},
+		{
+			name: "error-missing-file",
+			file: &File{
+				Name: "file-not-found",
+				stat: s,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.file.IsModified()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("File.IsModified(%q) error = %v, wantErr %v", tt.file.Name, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("File.IsModified() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type fakeRunner struct{}
+
+func (f *fakeRunner) Query(query string) ([]sql.Metric, error) {
+	return nil, fmt.Errorf("Fake failure")
+}
+
+func TestFile_Update(t *testing.T) {
+	tests := []struct {
+		name    string
+		c       *sql.Collector
+		wantErr bool
+	}{
+		{
+			name: "success",
+			c:    nil,
+		},
+		{
+			name:    "error-from-update",
+			c:       sql.NewCollector(&fakeRunner{}, prometheus.GaugeValue, "foo", ""),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &File{
+				Name: "example",
+				c:    tt.c,
+			}
+			if err := f.Update(); (err != nil) != tt.wantErr {
+				t.Errorf("File.Update() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+type fakeRegister struct {
+	metric sql.Metric
+}
+
+func (f *fakeRegister) Query(query string) ([]sql.Metric, error) {
+	return []sql.Metric{f.metric}, nil
+}
+
+func TestFile_Register(t *testing.T) {
+	fr := &fakeRegister{
+		metric: sql.NewMetric([]string{}, []string{}, map[string]float64{"": 1.23}),
+	}
+	x := sql.NewCollector(fr, prometheus.GaugeValue, "foo", "")
+	tests := []struct {
+		name          string
+		fileCollector *sql.Collector
+		newCollector  *sql.Collector
+		wantErr       bool
+	}{
+		{
+			// Register should succeed.
+			name:         "register-success",
+			newCollector: x,
+		},
+		{
+			// Try to register the same collector should return an error.
+			name:         "register-returns-error",
+			newCollector: x,
+			wantErr:      true,
+		},
+		{
+			// Unregister the same one registered above.
+			name:          "unregister-success",
+			fileCollector: x,
+			newCollector:  x,
+		},
+		{
+			// Try to unregister a collector that was never registered.
+			name:          "unregister-returns-error",
+			fileCollector: sql.NewCollector(&fakeRunner{}, prometheus.GaugeValue, "foo", ""),
+			wantErr:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &File{
+				Name: "example",
+				c:    tt.fileCollector,
+			}
+			if err := f.Register(tt.newCollector); (err != nil) != tt.wantErr {
+				t.Errorf("File.Register() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This package will replace the registration logic in `bigquery_exporter/main.go` to support file reload and and prometheus registration.

Basically, the `setup.File` methods support writing a register-update loop like:

```
modified, err := f.IsModified()
if modified && err == nil {
    c := sql.NewCollector(...)
    err = f.Register(c)
} else {
    err = f.Update()
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-bigquery-exporter/18)
<!-- Reviewable:end -->
