### PR TITLE
Update main to use setup.File interfaces

### DIFF
--- a/cmd/bigquery_exporter/main.go
+++ b/cmd/bigquery_exporter/main.go
@@ -87,7 +87,7 @@ func reloadRegisterUpdate(client *bigquery.Client, files []setup.File, vars map[
 				err = f.Update()
 			}
 			if err != nil {
-				log.Println(err)
+				log.Println("Error:", f.Name, err)
 			}
 			wg.Done()
 		}(&files[i])

--- a/cmd/bigquery_exporter/main_test.go
+++ b/cmd/bigquery_exporter/main_test.go
@@ -1,0 +1,70 @@
+// bigquery_exporter runs structured bigquery SQL and converts the results into
+// prometheus metrics. bigquery_exporter can process multiple queries.
+// Because BigQuery queries can have long run times and high cost, Query results
+// are cached and updated every refresh interval, not on every scrape of
+// prometheus metrics.
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/prometheus-bigquery-exporter/sql"
+)
+
+func init() {
+	log.SetOutput(ioutil.Discard)
+}
+
+type fakeRunner struct {
+	updated int
+}
+
+func (f *fakeRunner) Query(query string) ([]sql.Metric, error) {
+	r := []sql.Metric{
+		{
+			LabelKeys:   []string{"key"},
+			LabelValues: []string{"value"},
+			Values: map[string]float64{
+				"okay": 1.23,
+			},
+		},
+	}
+	f.updated++
+	if f.updated > 1 {
+		// Simulate an error after one successful query.
+		return nil, fmt.Errorf("Fake failure for testing")
+	}
+	return r, nil
+}
+
+func Test_main(t *testing.T) {
+	// Provide coverage of the original newRunner definition.
+	newRunner(nil)
+
+	// Create a fake runner for the test.
+	f := &fakeRunner{}
+	newRunner = func(*bigquery.Client) sql.QueryRunner {
+		return f
+	}
+
+	// Set the refresh period to a very small delay.
+	*refresh = time.Second
+	gaugeSources.Set("testdata/test.query")
+
+	// Reset mainCtx to timeout after a second.
+	mainCtx, mainCancel = context.WithTimeout(mainCtx, time.Second)
+	defer mainCancel()
+
+	main()
+
+	// Verify that the fakeRunner was called twice.
+	if f.updated != 2 {
+		t.Errorf("main() failed to update; got %d, want 2", f.updated)
+	}
+}

--- a/cmd/bigquery_exporter/main_test.go
+++ b/cmd/bigquery_exporter/main_test.go
@@ -10,10 +10,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/prometheus-bigquery-exporter/sql"
 )
 
@@ -44,6 +46,11 @@ func (f *fakeRunner) Query(query string) ([]sql.Metric, error) {
 }
 
 func Test_main(t *testing.T) {
+
+	tmp, err := ioutil.TempFile("", "empty_query_*")
+	rtx.Must(err, "Failed to create temp file for main test.")
+	defer os.Remove(tmp.Name())
+
 	// Provide coverage of the original newRunner definition.
 	newRunner(nil)
 
@@ -55,7 +62,7 @@ func Test_main(t *testing.T) {
 
 	// Set the refresh period to a very small delay.
 	*refresh = time.Second
-	gaugeSources.Set("testdata/test.query")
+	gaugeSources.Set(tmp.Name())
 
 	// Reset mainCtx to timeout after a second.
 	mainCtx, mainCancel = context.WithTimeout(mainCtx, time.Second)

--- a/cmd/bigquery_exporter/main_test.go
+++ b/cmd/bigquery_exporter/main_test.go
@@ -46,7 +46,6 @@ func (f *fakeRunner) Query(query string) ([]sql.Metric, error) {
 }
 
 func Test_main(t *testing.T) {
-
 	tmp, err := ioutil.TempFile("", "empty_query_*")
 	rtx.Must(err, "Failed to create temp file for main test.")
 	defer os.Remove(tmp.Name())


### PR DESCRIPTION
This change updates main to use the new setup.File interfaces and completes unit test coverage.

Note: this is a breaking change with respect to the original handling of flags. The flag package is changed from `github.com/spf13/pflag` so that we can take advantage of `flagx.ArgsFromEnv` and `flagx.StringArray`. As well, the separate flags for metric '--type' and '--query' filename are combined as `--guage-query`. This change removes support for counter queries, but adds a TODO. Counters are a special use-case that make queries more expensive and might be suited to a different collector implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-bigquery-exporter/21)
<!-- Reviewable:end -->
