### PR TITLE
Simplify declaration of Metric array

### DIFF
--- a/sql/collector_test.go
+++ b/sql/collector_test.go
@@ -33,12 +33,12 @@ func (qr *errorQueryRunner) Query(query string) ([]Metric, error) {
 
 func TestCollector(t *testing.T) {
 	metrics := []Metric{
-		Metric{
+		{
 			LabelKeys:   []string{"key"},
 			LabelValues: []string{"thing"},
 			Values:      map[string]float64{"": 1.1},
 		},
-		Metric{
+		{
 			LabelKeys:   []string{"key"},
 			LabelValues: []string{"thing2"},
 			Values:      map[string]float64{"": 2.1},


### PR DESCRIPTION
Fixes lint warning in Go report card.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-bigquery-exporter/23)
<!-- Reviewable:end -->
