### PR TITLE
Update README and add example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ successfully interpret and convert it into prometheus metrics.
 Metric names are derived from the query file name and query value columns.
 The bigquery-exporter identifies value columns by looking for column names
 that match the pattern: `value([.+])`. All characters in the matching group
-`([.+])` are appending to the metric prefix taken from the query file name.
+`([.+])` are appended to the metric prefix taken from the query file name.
 For example:
 
 * Filename: `bq_ndt_test.sql`

--- a/README.md
+++ b/README.md
@@ -1,121 +1,141 @@
 # prometheus-bigquery-exporter
-[![Version](https://img.shields.io/github/tag/m-lab/prometheus-bigquery-exporter.svg)](https://github.com/m-lab/prometheus-bigquery-exporter/releases) [![Build Status](https://travis-ci.org/m-lab/prometheus-bigquery-exporter.svg?branch=master)](https://travis-ci.org/m-lab/prometheus-bigquery-exporter) [![Coverage Status](https://coveralls.io/repos/m-lab/prometheus-bigquery-exporter/badge.svg?branch=master)](https://coveralls.io/github/m-lab/prometheus-bigquery-exporter?branch=master) [![GoDoc](https://godoc.org/github.com/m-lab/prometheus-bigquery-exporter?status.svg)](https://godoc.org/github.com/m-lab/prometheus-bigquery-exporter) [![Go Report Card](https://goreportcard.com/badge/github.com/m-lab/prometheus-bigquery-exporter)](https://goreportcard.com/report/github.com/m-lab/prometheus-bigquery-exporter) 
+
+[![Version](https://img.shields.io/github/tag/m-lab/prometheus-bigquery-exporter.svg)](https://github.com/m-lab/prometheus-bigquery-exporter/releases) [![Build Status](https://travis-ci.org/m-lab/prometheus-bigquery-exporter.svg?branch=master)](https://travis-ci.org/m-lab/prometheus-bigquery-exporter) [![Coverage Status](https://coveralls.io/repos/m-lab/prometheus-bigquery-exporter/badge.svg?branch=master)](https://coveralls.io/github/m-lab/prometheus-bigquery-exporter?branch=master) [![GoDoc](https://godoc.org/github.com/m-lab/prometheus-bigquery-exporter?status.svg)](https://godoc.org/github.com/m-lab/prometheus-bigquery-exporter) [![Go Report Card](https://goreportcard.com/badge/github.com/m-lab/prometheus-bigquery-exporter)](https://goreportcard.com/report/github.com/m-lab/prometheus-bigquery-exporter)
 
 An exporter for converting BigQuery results into Prometheus metrics.
 
-# Limitations
-
-## No historical values
+## Limitations: No historical values
 
 Prometheus collects the *current* status of a system as reported by an exporter.
 Prometheus then associates the values collected with a timestamp of the time of
 collection.
 
 *NOTE:* there is no way to associate historical values with timestamps in the
-the past!
+the past with this exporter!
 
 So, the results of queries run by prometheus-bigquery-exporter should represent
 a meaningful value at a fixed point in time relative to the time the query is
 made, e.g. total number of tests in a 5 minute window 1 hour ago.
 
-# Query format
+## Query Formatting
 
 The prometheus-bigquery-exporter accepts arbitrary BQ queries. However, the
 query results must be structured in a predictable way for the exporter to
 successfully interpret and convert it into prometheus metrics.
 
-Required columns:
+### Metric names and values
 
- * `value` -- every query result must have a "value". Values should be integers
-   or floats.
+Metric names are derived from the query file name and query value columns.
+The bigquery-exporter identifies value columns by looking for column names
+that match the pattern: `value([.+])`. All characters in the matching group
+`([.+])` are appending to the metric prefix taken from the query file name.
+For example:
 
-Optional columns:
+* Filename: `bq_ndt_test.sql`
+* Metric prefix: `bq_ndt_test`
+* Column name: `value_count`
+* Final metric: `bq_ndt_test_count`
 
- * If there is more than one result row, then the query must also define labels
-   to distinguish each value. Every column name that is not "value" will create
-   a label on the resulting metric. For example, results with two columns,
-   "machine" and "value" would create metrics with labels named "machine" and
-   values from the results for that row.
+Value columns are required (at least one):
 
-   Labels should be strings.
+* `value([.+])` - every query must define a result "value". Values must
+  be integers or floats. For a query to return multiple values, prefix each
+  with "value" and define unique suffixes.
 
-   There is no limit on the number of labels, but you should respect the
-   prometheus best practices by limiting label value cardinality.
+Label columns are optional:
 
-## Example query
+* If there is more than one result row, then the query must also define labels
+  to distinguish each value. Every column name that is not "value" will create
+  a label on the resulting metric. For example, results with two columns,
+  "machine" and "value" would create metrics with labels named "machine" and
+  values from the results for that row.
 
-The following query creates a "machine" label and counts the number of tests
+Labels must be strings:
 
-```
-# TODO: replace with query using views.
-# TODO: replace with standard SQL syntax.
-SELECT
-    -- All columns not named "value" are added as metric labels.
-    CONCAT(REPLACE(REGEXP_EXTRACT(task_filename,
-        r'gs://.*-(mlab[1-4]-[a-z]{3}[0-9]+)-ndt.*.tgz'), "-", "."),
-        ".measurement-lab.org") AS label_machine,
+* There is no limit on the number of labels, but you should respect the
+  prometheus best practices by limiting label value cardinality.
 
-    -- All queries must have a single column named "value"
-    count(*) as value
+Duplicate metrics are an error:
 
-FROM
-    [measurement-lab:public.ndt]
+* If the query returns multiple rows that are not distinguished by the set of
+  labels for each row.
 
-GROUP BY label_machine
-ORDER BY value
-```
+## Example Query
 
-Save the sample query to a file named "ndt_test_cound.sql". The metric name is
-derived from the file name. Start the exporter:
+The following query creates a label and groups by each label.
 
-```
-    bq_exporter --query counter=ndt_test_count.sql
-```
+  ```sql
+  -- Example data in place of an actual table of values.
+  WITH example_data as (
+      SELECT "a" as label, 5 as widgets
+      UNION ALL
+      SELECT "b" as label, 2 as widgets
+      UNION ALL
+      SELECT "b" as label, 3 as widgets
+  )
 
-Visit http://localhost:9393/metrics and you will find metrics like:
+  SELECT
+     label, SUM(widgets) as value
+  FROM
+     example_data
+  GROUP BY
+     label
+  ```
 
-```
-    ndt_test_count{machine="mlab1.foo01.measurement-lab.org"} 100
-    ndt_test_count{machine="mlab2.foo01.measurement-lab.org"} 200
+* Save the sample query to a file named "bq_example.sql".
+* Start the exporter:
+
+  ```sh
+  prometheus-bigquery-exporter -gauge-query bq_example.sql
+  ```
+
+* Visit http://localhost:9348/metrics and you will find metrics like:
+
+  ```txt
+    bq_example{label="a"} 5
+    bq_example{label="b"} 5
     ...
+  ```
+
+## Example Configuration
+
+Typical deployments will be in Kubernetes environment, like GKE.
+
+```sh
+# Change to the example directory.
+cd example
+# Deploy the example query as a configmap and example k8s deployment.
+./deploy.sh
 ```
 
+## Testing
 
-# Testing
-
-To run the bigquery exporter locally (e.g. with a new query) you can build a
-test environment based on the google/cloud-sdk with a golang tools installed.
+To run the bigquery exporter locally (e.g. with a new query) you can build
+and run locally.
 
 Use the following steps:
 
-1. Build the testing docker image.
+1. Build the docker image.
 
-```
-$ docker build -t bqe.testing -f Dockerfile.testing .
-```
+  ```sh
+  docker build -t bqx-local -f Dockerfile .
+  ```
 
-2. Run the testing image, with fowarded ports and shared volume. The
-   `--volumes-from` option is created automatically by the cloud-sdk base image.
-   This volume preserves credentials across runs of the docker image.
+2. Authenticate using your Google account. Both steps are necessary, the
+  first to run gcloud commands (which uses user credentials), the second to run
+  the bigquery exporter (which uses application default credentials).
 
-```
-$ docker run -p 9050:9050 --rm -ti -v $PWD:/go/src/github.com/m-lab/prometheus-bigquery-exporter --volumes-from gcloud-config bqe.testing
-```
+  ```sh
+  gcloud auth login
+  gcloud auth application-default login
+  ```
 
-3. Authenticate using your account. Both steps are necessary, the first to run
-   gcloud commands (which uses user credentials), the second to run the bigquery
-   exporter (which uses application default credentials).
+3. Run the image, with fowarded ports and access to gcloud credentials.
 
-```
-# gcloud auth login
-# gcloud auth application-default login
-```
-
-4. Start the bigquery exporter.
-
-```
-go get -v github.com/m-lab/prometheus-bigquery-exporter/cmd/bigquery_exporter
-./go/bin/bigquery_exporter \
-    --project mlab-sandbox \
-    --type gauge --query <path-to-some-query-file>/bq_ndt_metrics.sql
-```
+  ```sh
+  docker run -p 9348:9348 --rm \
+    -v $HOME/.config/gcloud:/root/.config/gcloud \
+    -v $PWD:/queries -it bqx-local \
+      -project $GCLOUD_PROJECT \
+      -guage-query /queries/example/config/bq_example.sql
+  ```

--- a/example/bigquery.yml
+++ b/example/bigquery.yml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bigquery-exporter-5m
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: bigquery-exporter
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+      labels:
+        run: bigquery-exporter
+    spec:
+      containers:
+      - name: bigquery-exporter
+        image: measurementlab/prometheus-bigquery-exporter:latest
+        args: [ "-project=mlab-sandbox",
+                "-refresh=1m",
+                "-gauge-query=/queries/bq_example.sql",
+              ]
+        ports:
+        - containerPort: 9050
+        volumeMounts:
+        - mountPath: /queries
+          name: bigquery-config
+
+      volumes:
+      - name: bigquery-config
+        configMap:
+          name: bigquery-exporter-config

--- a/example/config/bq_example.sql
+++ b/example/config/bq_example.sql
@@ -1,0 +1,15 @@
+-- Example query.
+WITH example_data as (
+    SELECT "a" as label, 5 as widgets
+    UNION ALL
+    SELECT "b" as label, 2 as widgets
+    UNION ALL
+    SELECT "b" as label, 3 as widgets
+)
+
+SELECT
+   label, SUM(widgets) as value
+FROM
+   example_data
+GROUP BY
+   label

--- a/example/deploy.sh
+++ b/example/deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# deploy.sh applies an example bigquery exporter to the currently
+# selected k8s cluster.
+#
+# Example:
+#
+# ./deploy.sh
+
+set -x
+set -e
+set -u
+
+# Apply the bigquery exporter configurations.
+kubectl create configmap bigquery-exporter-config \
+    --from-file=config \
+    --dry-run=client -o json | kubectl apply -f -
+
+kubectl apply -f bigquery.yml


### PR DESCRIPTION
This change provides a major update to the bqx README.md documentation and adds an example configuration for k8s and a sample query. The README walks through the provided example. The README does a better job of describing the expected column format for values and how metric names are derived.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-bigquery-exporter/32)
<!-- Reviewable:end -->
