### PR TITLE
Fix: Propagate registration error

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -55,7 +55,7 @@ func (f *File) Register(c *sql.Collector) error {
 		logx.Debug.Println("Unregister:", ok)
 		if !ok {
 			// This is a fatal error. If the
-			return fmt.Errorf("Failed to unregister %q", f.Name)
+			return fmt.Errorf("failed to unregister %q", f.Name)
 		}
 		f.c = nil
 	}
@@ -65,10 +65,10 @@ func (f *File) Register(c *sql.Collector) error {
 		// While collector Update could fail transiently, this may be a fatal error.
 		return err
 	}
-	logx.Debug.Println("Register: success:", f.Name)
+	logx.Debug.Println("Register:", f.Name, c.RegisterErr)
 	// Save the registered collector.
 	f.c = c
-	return nil
+	return c.RegisterErr
 }
 
 // Update runs the collector query again.

--- a/sql/collector.go
+++ b/sql/collector.go
@@ -51,6 +51,9 @@ type Collector struct {
 	metrics []Metric
 	// mux locks access to types above.
 	mux sync.Mutex
+
+	// RegisterErr contains any error during registration. This should be considered fatal.
+	RegisterErr error
 }
 
 // NewCollector creates a new BigQuery Collector instance.
@@ -76,6 +79,7 @@ func (col *Collector) Describe(ch chan<- *prometheus.Desc) {
 		err := col.Update()
 		if err != nil {
 			log.Println(err)
+			col.RegisterErr = err
 		}
 		col.setDesc()
 	}


### PR DESCRIPTION
This change preserves errors encountered during registration of the custom `sql.Collector`. Previously, if an error occurred during prometheus collector registration then the prometheus metrics for subsequent successful queries would not be reported. This change makes these errors fatal by making "RegisterErr" part of the public interface for the `sql.Collector`, and returned by `File.Register` which would make the error fatal in the future.

Testing: using existing unit tests.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-bigquery-exporter/34)
<!-- Reviewable:end -->
